### PR TITLE
Remove post hooks from pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,5 @@
 default_install_hook_types:
   - pre-commit
-  - post-checkout
-  - post-merge
-  - post-rewrite
   - commit-msg
 
 repos:

--- a/uv.lock
+++ b/uv.lock
@@ -594,7 +594,7 @@ wheels = [
 
 [[package]]
 name = "pytest-lf-skip"
-version = "0.2.0"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "pytest" },


### PR DESCRIPTION
Eliminate unnecessary post hooks from the pre-commit configuration to prevent constant unintended error messages.