### PR TITLE
Add all directories as safe for git in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,8 @@ jobs:
           path: dist/
 
       - name: Python Semantic Release
-        run: just release-no-build
+        run: |
+          git config --system --add safe.directory "*"
+          just release-no-build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Configure Git to treat all directories as safe before running the release command in the CI pipeline.