### PR TITLE
Update CI configuration for semantic release and remove Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # ensure tags are fetched
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -230,6 +232,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # ensure tags are fetched
 
       - uses: astral-sh/setup-uv@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,8 +240,6 @@ jobs:
           path: dist/
 
       - name: Python Semantic Release
-        run: |
-          git config --system --add safe.directory "*"
-          just release-no-build
+        run: just release-no-build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
           uv sync --group lint
           uv pip install pip
 
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit/
+          key: pre-commit|${{ hashFiles('.python-version', '.pre-commit-config.yaml') }}
+
       - run: |
             just lint pre-commit
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
 
       - uses: extractions/setup-just@v3
 
@@ -114,6 +116,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
 
       - name: Get coverage files
         uses: actions/download-artifact@v4
@@ -209,6 +213,8 @@ jobs:
           fetch-tags: true
 
       - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
 
       - uses: extractions/setup-just@v3
 
@@ -237,6 +243,8 @@ jobs:
           fetch-tags: true
 
       - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
 
       - uses: extractions/setup-just@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,8 +209,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # ensure tags are fetched
-          fetch-tags: true
+          fetch-depth: 1
+          fetch-tags: true  # ensure tags are fetched
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -239,8 +239,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # ensure tags are fetched
-          fetch-tags: true
+          fetch-depth: 1
+          fetch-tags: true  # ensure tags are fetched
 
       - uses: astral-sh/setup-uv@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,12 +142,6 @@ jobs:
           name: coverage-html
           path: htmlcov
 
-      - run: uv run coverage xml
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-
   coverage-pr-comment:
     needs: coverage-combine
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # ensure tags are fetched
+          fetch-tags: true
 
       - uses: astral-sh/setup-uv@v5
 
@@ -228,6 +229,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # ensure tags are fetched
+          fetch-tags: true
 
       - uses: astral-sh/setup-uv@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: '3.12'
 
       - uses: extractions/setup-just@v3
 
@@ -111,8 +109,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: '3.12'
 
       - name: Get coverage files
         uses: actions/download-artifact@v4
@@ -207,8 +203,6 @@ jobs:
           fetch-depth: 0  # ensure tags are fetched
 
       - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
 
       - uses: extractions/setup-just@v3
 
@@ -236,8 +230,6 @@ jobs:
           fetch-depth: 0  # ensure tags are fetched
 
       - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
 
       - uses: extractions/setup-just@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: astral-sh/setup-uv@v5
+
       - name: Download build artifacts
         uses: dawidd6/action-download-artifact@v9
         with:
@@ -29,5 +31,7 @@ jobs:
           name: build-artifacts
           path: dist/
 
+      # TODO: run smoke tests on the built package here
+
       - name: Upload package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        run: uv publish --trusted-publishing always

--- a/tests/test_lf_skip.py
+++ b/tests/test_lf_skip.py
@@ -203,3 +203,9 @@ def test_lfnf_none(
         run_args,
         expected_results,
     )
+
+
+def test_package_version() -> None:
+    from pytest_lf_skip import __version__
+
+    assert __version__ != "0.0.0"


### PR DESCRIPTION
Refactor CI setup by removing Codecov integration, ensuring tags are checked out during the semantic release process, and updating the release command to use `uv publish`. Additionally, remove the Python version pinning and explicit safe directory setting.