### PR TITLE
Update CI configuration for semantic release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
 
       - name: Generate release bot app token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.RELEASER_ID }}
           private-key: ${{ secrets.RELEASER_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,7 @@ jobs:
   semantic-release:
     needs: [build]
     runs-on: ubuntu-latest
+    environment: release
     if: github.event_name != 'pull_request' && needs.build.result == 'success'
     permissions:
       contents: write


### PR DESCRIPTION
Bump the version of the create-github-app-token action and specify the environment for the semantic release job.