### PR TITLE
Update CI environments for release control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
   semantic-release:
     needs: [build]
     runs-on: ubuntu-latest
-    environment: release
+    environment: gh-release
     if: github.event_name != 'pull_request' && needs.build.result == 'success'
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: release
+    environment: pypi-release
 
     permissions:
       id-token: write


### PR DESCRIPTION
Refine the CI environments for better release management by using seperate environmens for github and pypi releases.