### PR TITLE
ci: add path mappings to prevent ci errors during `coverage combine`

### DIFF
--- a/.github/workflows/_validate.yml
+++ b/.github/workflows/_validate.yml
@@ -389,7 +389,7 @@ jobs:
         run: |
           uv pip install coverage[toml]
           ls -la coverage
-          uv run coverage combine coverage
+          uv run coverage combine --debug=pathmap coverage
 
       - name: Store artifact | Store coverage data
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,12 @@ addopts = [
     "--color=yes",
 ]
 
+[tool.coverage.paths]
+source = [
+    "src/pytest_lf_skip/",
+    ".venv/*/pytest_lf_skip/",
+]
+
 [tool.coverage.report]
 skip_empty = true
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ addopts = [
 [tool.coverage.paths]
 source = [
     "src/pytest_lf_skip/",
-    ".venv/*/pytest_lf_skip/",
+    ".venv/**/pytest_lf_skip/",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
The first path in the list is the real source path, the others are used to map a runner path onto the real source path.