### PR TITLE
chore: correct formatting of auto-approve review message in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,5 @@ jobs:
 
       - uses: hmarr/auto-approve-action@v4
         with:
-          review-message: "Auto-approved due to PR being created by ${{ github.repository_owner }} (the repository owner)."
+          review-message: "Auto-approved due to PR being created by @${{ github.repository_owner }} (the repository owner)."
           github-token: ${{ steps.setup-bot.outputs.token }}


### PR DESCRIPTION
Correct the formatting of the auto-approve review message to include an '@' symbol before the repository owner's name.