### PR TITLE
chore: ensure validation job only runs for non-cd bot users

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   validate:
     uses: ./.github/workflows/_validate.yml
+    if: github.actor != 'alexfayers-auto-cd[bot]'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Modify the validation job to skip execution for the CD bot user, improving workflow efficiency.